### PR TITLE
Change Buzz to be an optional dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,11 +14,10 @@
     ],
 
     "require": {
-        "php": ">=5.3.0",
-        "kriswallsmith/buzz" : "*"
-
+        "php": ">=5.3.0"
     },
     "suggests": {
+        "kriswallsmith/buzz" : "*",
         "guzzle/guzzle": "*"
     },
 


### PR DESCRIPTION
As Buzz is a required dependency, then if Guzzle is installed both libraries are available which is redundant.
