### PR TITLE
DIC: Use of "RequestStack" instead "Request" (Symfony 2.4)

### DIFF
--- a/Akismet/AkismetReal.php
+++ b/Akismet/AkismetReal.php
@@ -4,19 +4,21 @@ namespace Ornicar\AkismetBundle\Akismet;
 
 use Symfony\Component\HttpFoundation\Request;
 use Ornicar\AkismetBundle\Adapter\AkismetAdapterInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Log\LoggerInterface;
 
 /**
  * Detects spam by querying the Akismet service.
  *
  * @author Thibault Duplessis <thibault.duplessis@gmail.com>
+ * @author Jean-Louis Pirson <jl.pirson@grizzlylab.be>
  */
 class AkismetReal implements AkismetInterface
 {
     /**
      * @var Request
      */
-    protected $request;
+    protected $requestStack;
 
     /**
      * @var AkismetAdapterInterface
@@ -41,13 +43,14 @@ class AkismetReal implements AkismetInterface
      * Constructor.
      *
      * @param AkismetAdapterInterface $adapter
-     * @param Request $request
+     * @param RequestStack $requestStack
      * @param boolean $throwExceptions if false, exceptions are just ignored
      */
-    public function __construct(AkismetAdapterInterface $adapter, Request $request, $throwExceptions, LoggerInterface $logger = null)
+    public function __construct(AkismetAdapterInterface $adapter, RequestStack $requestStack, $throwExceptions, LoggerInterface $logger = null)
     {
         $this->adapter = $adapter;
-        $this->request = $request;
+        $this->requestStack = $requestStack;
+        $this->currentRequest = $requestStack->getCurrentRequest();
         $this->throwExceptions = $throwExceptions;
         $this->logger = $logger;
     }
@@ -91,10 +94,10 @@ class AkismetReal implements AkismetInterface
     protected function getRequestData()
     {
         return array(
-            'permalink'  => $this->request->getUri(),
-            'user_ip'    => $this->request->getClientIp(),
-            'user_agent' => $this->request->server->get('HTTP_USER_AGENT'),
-            'referrer'   => $this->request->server->get('HTTP_REFERER'),
+            'permalink' => $this->currentRequest->getUri(),
+            'user_ip' => $this->currentRequest->getClientIp(),
+            'user_agent' => $this->currentRequest->get('HTTP_USER_AGENT'),
+            'referrer' => $this->currentRequest->get('HTTP_REFERER')
         );
     }
 }

--- a/Resources/config/config.xml
+++ b/Resources/config/config.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <container xmlns="http://symfony.com/schema/dic/services"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
 
         <service id="ornicar_akismet.akismet_stub" class="Ornicar\AkismetBundle\Akismet\AkismetStub" public="false" />
 
-        <service id="ornicar_akismet.akismet_real" class="Ornicar\AkismetBundle\Akismet\AkismetReal" scope="request" public="false">
+        <service id="ornicar_akismet.akismet_real" class="Ornicar\AkismetBundle\Akismet\AkismetReal" public="false">
             <argument type="service" id="ornicar_akismet.adapter" />
-            <argument type="service" id="request" />
+            <argument type="service" id="request_stack" />
             <argument /> <!-- throw exceptions -->
             <argument type="service" id="logger" on-invalid="null" />
         </service>

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": ">=5.3.0",
         "kriswallsmith/buzz" : "*",
-        "symfony/symfony": "2.4.*"
+        "symfony/http-foundation": "~2.4.*"
     },
     "suggests": {
         "guzzle/guzzle": "*"

--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,8 @@
 
     "require": {
         "php": ">=5.3.0",
-        "kriswallsmith/buzz" : "*"
-
+        "kriswallsmith/buzz" : "*",
+        "symfony/symfony": "2.4.*"
     },
     "suggests": {
         "guzzle/guzzle": "*"

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": ">=5.3.0",
         "kriswallsmith/buzz" : "*",
-        "symfony/http-foundation": "~2.4.*"
+        "symfony/http-foundation": "~2.4"
     },
     "suggests": {
         "guzzle/guzzle": "*"


### PR DESCRIPTION
- Do not use the scope "request" anymore.
- Use "RequestStack" instead "Request" in AkismetReal.php.
- Update composer.json to require Symfony 2.4.
