### PR TITLE
add branch-alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,5 +25,10 @@
     "autoload": {
         "psr-0": { "Ornicar\\AkismetBundle": "" }
     },
-    "target-dir": "Ornicar/AkismetBundle"
+    "target-dir": "Ornicar/AkismetBundle",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.0.x-dev"
+        }
+    }
 }


### PR DESCRIPTION
This is useful to avoid forcing use of "dev-master" in user's composer.json
With this change, it's possible to use "1.0.*@dev" instead.
Of course, a better solution would be tag a stable versione, but this is better than nothing :stuck_out_tongue:
