### PR TITLE
Add branch-alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,5 +25,10 @@
     "autoload": {
         "psr-0": { "Ornicar\\AkismetBundle": "" }
     },
-    "target-dir": "Ornicar/AkismetBundle"
+    "target-dir": "Ornicar/AkismetBundle",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.0.x-dev"
+        }
+    }
 }


### PR DESCRIPTION
To allow using "^1.0@dev" in requirements, instead of "dev-master"
