### PR TITLE
Initial Symfony 3.0 support

### DIFF
--- a/Akismet/AkismetReal.php
+++ b/Akismet/AkismetReal.php
@@ -2,7 +2,7 @@
 
 namespace Ornicar\AkismetBundle\Akismet;
 
-use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Ornicar\AkismetBundle\Adapter\AkismetAdapterInterface;
 use Symfony\Component\HttpKernel\Log\LoggerInterface;
 
@@ -14,9 +14,9 @@ use Symfony\Component\HttpKernel\Log\LoggerInterface;
 class AkismetReal implements AkismetInterface
 {
     /**
-     * @var Request
+     * @var RequestStack
      */
-    protected $request;
+    protected $requestStack;
 
     /**
      * @var AkismetAdapterInterface
@@ -38,16 +38,15 @@ class AkismetReal implements AkismetInterface
     protected $logger;
 
     /**
-     * Constructor.
-     *
      * @param AkismetAdapterInterface $adapter
-     * @param Request $request
+     * @param RequestStack $requestStack
      * @param boolean $throwExceptions if false, exceptions are just ignored
+     * @param LoggerInterface|null $logger
      */
-    public function __construct(AkismetAdapterInterface $adapter, Request $request, $throwExceptions, LoggerInterface $logger = null)
+    public function __construct(AkismetAdapterInterface $adapter, RequestStack $requestStack, $throwExceptions, LoggerInterface $logger = null)
     {
         $this->adapter = $adapter;
-        $this->request = $request;
+        $this->requestStack = $requestStack;
         $this->throwExceptions = $throwExceptions;
         $this->logger = $logger;
     }
@@ -90,11 +89,16 @@ class AkismetReal implements AkismetInterface
      */
     protected function getRequestData()
     {
+        $request = $this->requestStack->getCurrentRequest();
+        if (null === $request) {
+            throw new \RuntimeException('No current request found.');
+        }
+
         return array(
-            'permalink'  => $this->request->getUri(),
-            'user_ip'    => $this->request->getClientIp(),
-            'user_agent' => $this->request->server->get('HTTP_USER_AGENT'),
-            'referrer'   => $this->request->server->get('HTTP_REFERER'),
+            'permalink'  => $request->getUri(),
+            'user_ip'    => $request->getClientIp(),
+            'user_agent' => $request->server->get('HTTP_USER_AGENT'),
+            'referrer'   => $request->server->get('HTTP_REFERER'),
         );
     }
 }

--- a/Resources/config/config.xml
+++ b/Resources/config/config.xml
@@ -8,9 +8,9 @@
 
         <service id="ornicar_akismet.akismet_stub" class="Ornicar\AkismetBundle\Akismet\AkismetStub" public="false" />
 
-        <service id="ornicar_akismet.akismet_real" class="Ornicar\AkismetBundle\Akismet\AkismetReal" scope="request" public="false">
+        <service id="ornicar_akismet.akismet_real" class="Ornicar\AkismetBundle\Akismet\AkismetReal" shared="false">
             <argument type="service" id="ornicar_akismet.adapter" />
-            <argument type="service" id="request" />
+            <argument type="service" id="request_stack" />
             <argument /> <!-- throw exceptions -->
             <argument type="service" id="logger" on-invalid="null" />
         </service>

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
 
     "require": {
         "php": ">=5.3.0",
+        "symfony/framework-bundle": "~2.8|~3.0",
         "kriswallsmith/buzz" : "*"
 
     },


### PR DESCRIPTION
Fixed:

```The "scope" attribute of service "ornicar_akismet.akismet_real" in file "vendor/ornicar/akismet-bundle/Ornicar/AkismetBundle/DependencyInjection/../Resources/config/config.xml" is deprecated since version 2.8 and will be removed in 3.0.```

It would be nice to tag a new version after we merge this.